### PR TITLE
fix #60 - Support for images with multiple objects in Dataset class

### DIFF
--- a/detecto/core.py
+++ b/detecto/core.py
@@ -149,7 +149,7 @@ class Dataset(torch.utils.data.Dataset):
         image = read_image(img_name)
 
         # Read in xmin, ymin, xmax, and ymax
-        box = self._csv.iloc[idx, 4:]
+        box = self._csv.iloc[idx, 4:8]
         box = torch.tensor(box).view(1, 4)
 
         # Read in the label

--- a/detecto/tests/test_core.py
+++ b/detecto/tests/test_core.py
@@ -12,13 +12,13 @@ from torchvision.models.detection.faster_rcnn import FastRCNNPredictor
 def test_dataset():
     # Test the format of the values returned by indexing the dataset
     dataset = get_dataset()
-    assert len(dataset) == 2
+    assert len(dataset) == 1  # there is only one image in the dataset (label.xml)
     assert isinstance(dataset[0][0], torch.Tensor)
     assert isinstance(dataset[0][1], dict)
     assert dataset[0][0].shape == (3, 1080, 1720)
     assert 'boxes' in dataset[0][1] and 'labels' in dataset[0][1]
-    assert dataset[0][1]['boxes'].shape == (1, 4)
-    assert dataset[0][1]['labels'] == 'start_tick'
+    assert dataset[0][1]['boxes'].shape == (2, 4)
+    assert dataset[0][1]['labels'] == ['start_tick', 'start_gate']
 
     transform = transforms.Compose([
         transforms.ToPILImage(),
@@ -29,20 +29,20 @@ def test_dataset():
 
     # Test that the transforms are properly applied
     dataset = get_dataset(transform=transform)
-    assert dataset[1][0].shape == (3, 108, 172)
-    assert torch.all(dataset[1][1]['boxes'][0] == torch.tensor([6, 41, 171, 107]))
+    assert dataset[0][0].shape == (3, 108, 172)
+    assert torch.all(dataset[0][1]['boxes'][1] == torch.tensor([6, 41, 171, 107]))
 
     # Test works when given an XML folder
     path = os.path.dirname(__file__)
     input_folder = os.path.join(path, 'static')
 
     dataset = Dataset(input_folder, input_folder)
-    assert len(dataset) == 2
+    assert len(dataset) == 1
     assert dataset[0][0].shape == (3, 1080, 1720)
     assert 'boxes' in dataset[0][1] and 'labels' in dataset[0][1]
 
     dataset = Dataset(input_folder)
-    assert len(dataset) == 2
+    assert len(dataset) == 1
     assert dataset[0][0].shape == (3, 1080, 1720)
     assert 'boxes' in dataset[0][1] and 'labels' in dataset[0][1]
 
@@ -75,14 +75,14 @@ def test_dataloader():
         iterations += 1
 
         assert isinstance(data, tuple)
-        assert len(data) == 2
+        assert len(data) == 2  # data[0] = image tensor, data[1] = targets dictionary
         assert isinstance(data[0], list)
-        assert len(data[0]) == 2
+        assert len(data[0]) == 1  # only one image in data[0] since label.xml contains one image only.
 
         assert isinstance(data[0][0], torch.Tensor)
-        assert isinstance(data[0][1], torch.Tensor)
-        assert 'boxes' in dataset[0][1] and 'labels' in dataset[1][1]
+        assert 'boxes' in data[1][0] and 'labels' in data[1][0]
 
+    assert 'boxes' in dataset[0][1] and 'labels' in dataset[0][1]
     assert iterations == 1
 
 

--- a/detecto/utils.py
+++ b/detecto/utils.py
@@ -223,7 +223,7 @@ def xml_to_csv(xml_folder, output_file=None):
     """Converts a folder of XML label files into a pandas DataFrame and/or
     CSV file, which can then be used to create a :class:`detecto.core.Dataset`
     object. Each XML file should correspond to an image and contain the image
-    name, image size, and the names and bounding boxes of the objects in the
+    name, image size, image_id and the names and bounding boxes of the objects in the
     image, if any. Extraneous data in the XML files will simply be ignored.
     See :download:`here <../_static/example.xml>` for an example XML file.
     For an image labeling tool that produces XML files in this format,
@@ -249,6 +249,7 @@ def xml_to_csv(xml_folder, output_file=None):
     """
 
     xml_list = []
+    image_id = 0
     # Loop through every XML file
     for xml_file in glob(xml_folder + '/*.xml'):
         tree = ET.parse(xml_file)
@@ -266,11 +267,13 @@ def xml_to_csv(xml_folder, output_file=None):
 
             # Add image file name, image size, label, and box coordinates to CSV file
             row = (filename, width, height, label, int(float(box[0].text)),
-                   int(float(box[1].text)), int(float(box[2].text)), int(float(box[3].text)))
+                   int(float(box[1].text)), int(float(box[2].text)), int(float(box[3].text)), image_id)
             xml_list.append(row)
+        
+        image_id += 1
 
     # Save as a CSV file
-    column_names = ['filename', 'width', 'height', 'class', 'xmin', 'ymin', 'xmax', 'ymax']
+    column_names = ['filename', 'width', 'height', 'class', 'xmin', 'ymin', 'xmax', 'ymax', 'image_id']
     xml_df = pd.DataFrame(xml_list, columns=column_names)
 
     if output_file is not None:


### PR DESCRIPTION
**Problem:** If a single image contains more than one object, then the dataset class treats each object as a separate item in the dataset. As a result, if there are 'n' objects for any image 'i', then the same image 'i' is repeated in the dataset 'n' times, one time for each object.


**Changes:** 
* ```xml_to_csv()``` in utils.py was changed to add unique index "image_id" attribute for each image. 
* ```Dataset.__getitem__(self, idx)``` in core.py was modified to use "image_id" to index the images. Transformations code also changed to support multiple bounding boxes/labels in the same image. 
* ```Model._convert_to_int_labels()``` in core.py changed to support multiple bounding boxes/labels in the same image. 
* Changed 

**Tests:** Passing. 
* Modified ```test_dataloader()``` and  ```test_dataset()``` to ensure compatibility with changes made.

For more information, look at [Issue#60](https://github.com/alankbi/detecto/issues/60).


