### PR TITLE
Added option for mobile-based models

### DIFF
--- a/detecto/core.py
+++ b/detecto/core.py
@@ -241,6 +241,8 @@ class Model:
         :param pretrained: (Optional) Whether to load pretrained weights or not.
             Defaults to True. 
         :type pretrained: bool
+        :param modelname: (Optional) Name of the pretrained model
+        :type modelname: str
 
         **Example**::
 
@@ -258,6 +260,8 @@ class Model:
             self._model = torchvision.models.detection.fasterrcnn_mobilenet_v3_large_fpn(pretrained=pretrained)
         elif modelname == "fasterrcnn_mobilenet_v3_large_320_fpn":
             self._model = torchvision.models.detection.fasterrcnn_mobilenet_v3_large_320_fpn(pretrained=pretrained)
+        else:
+            return ValueError("Unknown Pretrained Model")
 
         if classes:
             # Get the number of input features for the classifier

--- a/detecto/core.py
+++ b/detecto/core.py
@@ -219,7 +219,7 @@ class Dataset(torch.utils.data.Dataset):
 
 class Model:
 
-    def __init__(self, classes=None, device=None, pretrained=True):
+    def __init__(self, classes=None, device=None, pretrained=True, modelname="fasterrcnn_resnet50_fpn"):
         """Initializes a machine learning model for object detection.
         Models are built on top of PyTorch's `pre-trained models
         <https://pytorch.org/docs/stable/torchvision/models.html>`_,
@@ -252,7 +252,12 @@ class Model:
         self._device = device if device else config['default_device']
 
         # Load a model pre-trained on COCO
-        self._model = torchvision.models.detection.fasterrcnn_resnet50_fpn(pretrained=pretrained)
+        if modelname == "fasterrcnn_resnet50_fpn":
+            self._model = torchvision.models.detection.fasterrcnn_resnet50_fpn(pretrained=pretrained)
+        elif modelname == "fasterrcnn_mobilenet_v3_large_fpn":
+            self._model = torchvision.models.detection.fasterrcnn_mobilenet_v3_large_fpn(pretrained=pretrained)
+        elif modelname == "fasterrcnn_mobilenet_v3_large_320_fpn":
+            self._model = torchvision.models.detection.fasterrcnn_mobilenet_v3_large_320_fpn(pretrained=pretrained)
 
         if classes:
             # Get the number of input features for the classifier

--- a/detecto/core.py
+++ b/detecto/core.py
@@ -219,7 +219,7 @@ class Dataset(torch.utils.data.Dataset):
 
 class Model:
 
-    def __init__(self, classes=None, device=None, pretrained=True, modelname="fasterrcnn_resnet50_fpn"):
+    def __init__(self, classes=None, device=None, pretrained=True, modelname='fasterrcnn_resnet50_fpn'):
         """Initializes a machine learning model for object detection.
         Models are built on top of PyTorch's `pre-trained models
         <https://pytorch.org/docs/stable/torchvision/models.html>`_,
@@ -254,14 +254,14 @@ class Model:
         self._device = device if device else config['default_device']
 
         # Load a model pre-trained on COCO
-        if modelname == "fasterrcnn_resnet50_fpn":
+        if modelname == 'fasterrcnn_resnet50_fpn':
             self._model = torchvision.models.detection.fasterrcnn_resnet50_fpn(pretrained=pretrained)
-        elif modelname == "fasterrcnn_mobilenet_v3_large_fpn":
+        elif modelname == 'fasterrcnn_mobilenet_v3_large_fpn':
             self._model = torchvision.models.detection.fasterrcnn_mobilenet_v3_large_fpn(pretrained=pretrained)
-        elif modelname == "fasterrcnn_mobilenet_v3_large_320_fpn":
+        elif modelname == 'fasterrcnn_mobilenet_v3_large_320_fpn':
             self._model = torchvision.models.detection.fasterrcnn_mobilenet_v3_large_320_fpn(pretrained=pretrained)
         else:
-            return ValueError("Unknown Pretrained Model")
+            return ValueError('Unknown Pretrained Model')
 
         if classes:
             # Get the number of input features for the classifier


### PR DESCRIPTION
I have added an optional parameter `modelname` for `core.Model` to provide more flexibility for the programmer to decide which pre-trained model to use.