### PR TITLE
Adds errors to show failure in `read_image`

### DIFF
--- a/detecto/tests/test_utils.py
+++ b/detecto/tests/test_utils.py
@@ -1,5 +1,6 @@
 import os
 import pandas as pd
+import pytest
 import torch
 import torchvision
 
@@ -56,6 +57,24 @@ def test_read_image():
     image = get_image()
 
     assert (read_image(image_path) == image).all()
+
+
+def test_read_image_fails_with_image_not_found():
+    image_path = "foo/bar"
+
+    with pytest.raises(ValueError) as e:
+        read_image(image_path)
+
+    assert "Could not read image foo/bar" == str(e.value)
+
+
+def test_read_image_fails_with_cv_error():
+    image_path = "static/demo.gif"
+
+    with pytest.raises(ValueError) as e:
+        read_image(image_path)
+
+    assert "Could not convert image color:" in str(e.value)
 
 
 def test_split_video():

--- a/detecto/utils.py
+++ b/detecto/utils.py
@@ -129,9 +129,17 @@ def read_image(path):
         >>> plt.imshow(image)
         >>> plt.show()
     """
+    if not os.path.isfile(path):
+        raise ValueError(f"Could not read image {path}")
 
     image = cv2.imread(path)
-    return cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
+
+    try:
+        rgb_image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
+    except cv2.error as e:
+        raise ValueError(f"Could not convert image color: {str(e)}")
+
+    return rgb_image
 
 
 def reverse_normalize(image):


### PR DESCRIPTION
Resolves: #78 

The following conditions were not being handled in `read_image` and were not visible to the user:

- When an image path that is given does not exist then it does not convey this information to the user.
- Images read by the OpenCV might not be a proper image or the format is not proper which might result in it failing.

This adds value errors that shows the failure condition to the user.