### PR TITLE
Fix model test

### DIFF
--- a/detecto/tests/__init__.py
+++ b/detecto/tests/__init__.py
@@ -1,1 +1,27 @@
 from .helpers import get_image
+from requests import get
+import logging
+import os
+
+MODEL_URL = "https://www.dropbox.com/s/kjalrfs3la97du8/model.pth?dl=1"
+LOGGER = logging.getLogger(__name__)
+
+
+def _download_model_file():
+    path = os.path.dirname(__file__)
+    model_path = os.path.join(path, 'static/model.pth')
+
+    if os.path.isfile(model_path):
+        LOGGER.info("Model file already exists. Continuing.")
+        return
+
+    LOGGER.info("\nDownloading model file......")
+
+    with open(model_path, "wb") as model_file:
+        response = get(MODEL_URL)
+        model_file.write(response.content)
+
+    LOGGER.info("Done")
+
+
+_download_model_file()

--- a/detecto/tests/test_utils.py
+++ b/detecto/tests/test_utils.py
@@ -1,12 +1,9 @@
-import os
-import pandas as pd
 import pytest
-import torch
 import torchvision
 
-from .helpers import get_image
 from detecto.utils import *
 from detecto.utils import _is_iterable
+from .helpers import get_image
 
 
 def test_filter_top_predictions():
@@ -69,7 +66,8 @@ def test_read_image_fails_with_image_not_found():
 
 
 def test_read_image_fails_with_cv_error():
-    image_path = 'static/demo.gif'
+    path = os.path.dirname(__file__)
+    image_path = os.path.join(path, 'static/demo.gif')
 
     with pytest.raises(ValueError) as e:
         read_image(image_path)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ sphinx
 torch==1.8.0
 torchvision==0.10.0
 tqdm
+requests~=2.26.0


### PR DESCRIPTION
Resolves: #95 

Adds a method that will run before the tests. This method checks if the model file `model.pth` exists in the local.
If the file:
- `exists`, then it doesn't download
- `doesn't exist`, then downloads it from the link mentioned in the issue.

Other:
- Refactored the test case for `read_image`
- Removed unused imports from `test_utils.py`
- Added package entry for `requests` needed for downloading file into `requirements.txt`